### PR TITLE
Initial POC of Message Type provider system

### DIFF
--- a/database/factories/MessageFactory.php
+++ b/database/factories/MessageFactory.php
@@ -4,6 +4,7 @@ namespace RTippin\Messenger\Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Model;
+use RTippin\Messenger\Facades\MessengerTypes;
 use RTippin\Messenger\Models\Message;
 
 /**
@@ -29,7 +30,7 @@ class MessageFactory extends Factory
     public function definition(): array
     {
         return [
-            'type' => Message::MESSAGE,
+            'type' => MessengerTypes::code('MESSAGE'),
             'body' => $this->faker->realText(rand(10, 200), rand(1, 4)),
             'edited' => false,
             'reacted' => false,
@@ -55,7 +56,7 @@ class MessageFactory extends Factory
     public function image(): self
     {
         return $this->state([
-            'type' => Message::IMAGE_MESSAGE,
+            'type' => MessengerTypes::code('IMAGE_MESSAGE'),
             'body' => 'picture.jpg',
         ]);
     }
@@ -68,7 +69,7 @@ class MessageFactory extends Factory
     public function document(): self
     {
         return $this->state([
-            'type' => Message::DOCUMENT_MESSAGE,
+            'type' => MessengerTypes::code('DOCUMENT_MESSAGE'),
             'body' => 'document.pdf',
         ]);
     }
@@ -81,7 +82,7 @@ class MessageFactory extends Factory
     public function audio(): self
     {
         return $this->state([
-            'type' => Message::AUDIO_MESSAGE,
+            'type' => MessengerTypes::code('AUDIO_MESSAGE'),
             'body' => 'sound.mp3',
         ]);
     }
@@ -94,7 +95,7 @@ class MessageFactory extends Factory
     public function video(): self
     {
         return $this->state([
-            'type' => Message::VIDEO_MESSAGE,
+            'type' => MessengerTypes::code('VIDEO_MESSAGE'),
             'body' => 'video.mov',
         ]);
     }

--- a/src/Actions/Messages/NewMessageAction.php
+++ b/src/Actions/Messages/NewMessageAction.php
@@ -10,6 +10,7 @@ use RTippin\Messenger\Broadcasting\NewMessageBroadcast;
 use RTippin\Messenger\Contracts\BroadcastDriver;
 use RTippin\Messenger\Contracts\MessengerProvider;
 use RTippin\Messenger\Events\NewMessageEvent;
+use RTippin\Messenger\Facades\MessengerTypes;
 use RTippin\Messenger\Http\Request\BaseMessageRequest;
 use RTippin\Messenger\Http\Resources\MessageResource;
 use RTippin\Messenger\Models\Bot;
@@ -277,7 +278,7 @@ abstract class NewMessageAction extends BaseMessengerAction
      */
     private function shouldMarkRead(): bool
     {
-        return in_array($this->messageType, Message::NonSystemTypes)
+        return in_array($this->messageType, MessengerTypes::getNonSystemTypes())
             && ! $this->messageOwner instanceof Bot;
     }
 

--- a/src/Actions/Messages/StoreMessage.php
+++ b/src/Actions/Messages/StoreMessage.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\DatabaseManager;
 use RTippin\Messenger\Contracts\BroadcastDriver;
 use RTippin\Messenger\Contracts\EmojiInterface;
+use RTippin\Messenger\Facades\MessengerTypes;
 use RTippin\Messenger\Http\Request\MessageRequest;
 use RTippin\Messenger\Messenger;
 use RTippin\Messenger\Models\Message;
@@ -67,7 +68,7 @@ class StoreMessage extends NewMessageAction
                             ?string $senderIp = null): self
     {
         $this->setThread($thread)
-            ->setMessageType(Message::MESSAGE)
+            ->setMessageType(MessengerTypes::code('MESSAGE'))
             ->setMessageBody($this->emoji->toShort($params['message']) ?: null)
             ->setMessageOptionalParameters($params)
             ->setMessageOwner($this->messenger->getProvider())

--- a/src/Contracts/MessageTypeProvider.php
+++ b/src/Contracts/MessageTypeProvider.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace RTippin\Messenger\Contracts;
+
+use RTippin\Messenger\Models\Message;
+
+interface MessageTypeProvider
+{
+
+    public function getVerbose(): string;
+
+    public function getCode(): int;
+
+    public function isSystemType(): bool;
+
+    public function getResourceData(Message $message): ?array;
+
+}

--- a/src/Contracts/MessageTypeProvider.php
+++ b/src/Contracts/MessageTypeProvider.php
@@ -6,7 +6,6 @@ use RTippin\Messenger\Models\Message;
 
 interface MessageTypeProvider
 {
-
     public function getVerbose(): string;
 
     public function getCode(): int;
@@ -14,5 +13,4 @@ interface MessageTypeProvider
     public function isSystemType(): bool;
 
     public function getResourceData(Message $message): ?array;
-
 }

--- a/src/Facades/MessengerTypes.php
+++ b/src/Facades/MessengerTypes.php
@@ -3,9 +3,6 @@
 namespace RTippin\Messenger\Facades;
 
 use Illuminate\Support\Facades\Facade;
-use RTippin\Messenger\Contracts\MessengerProvider;
-use RTippin\Messenger\Models\GhostUser;
-use RTippin\Messenger\Models\Participant;
 
 /**
  * @mixin \RTippin\Messenger\MessengerTypes

--- a/src/Facades/MessengerTypes.php
+++ b/src/Facades/MessengerTypes.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace RTippin\Messenger\Facades;
+
+use Illuminate\Support\Facades\Facade;
+use RTippin\Messenger\Contracts\MessengerProvider;
+use RTippin\Messenger\Models\GhostUser;
+use RTippin\Messenger\Models\Participant;
+
+/**
+ * @mixin \RTippin\Messenger\MessengerTypes
+ *
+ * @see \RTippin\Messenger\MessengerTypes
+ */
+class MessengerTypes extends Facade
+{
+    /**
+     * Get the registered name of the component.
+     *
+     * @return string
+     */
+    protected static function getFacadeAccessor(): string
+    {
+        return \RTippin\Messenger\MessengerTypes::class;
+    }
+}

--- a/src/Http/Resources/MessageResource.php
+++ b/src/Http/Resources/MessageResource.php
@@ -130,5 +130,4 @@ class MessageResource extends JsonResource
                 : $this->message->reactions()->with('owner')->get()
         ))->resolve();
     }
-
 }

--- a/src/Http/Resources/MessageResource.php
+++ b/src/Http/Resources/MessageResource.php
@@ -90,18 +90,7 @@ class MessageResource extends JsonResource
             'reactions' => $this->when($this->addRelatedItems && $this->message->isReacted(),
                 fn () => $this->addReactions()
             ),
-            'document' => $this->when($this->message->isDocument(),
-                fn () => $this->message->getDocumentDownloadRoute()
-            ),
-            'audio' => $this->when($this->message->isAudio(),
-                fn () => $this->message->getAudioDownloadRoute()
-            ),
-            'video' => $this->when($this->message->isVideo(),
-                fn () => $this->message->getVideoDownloadRoute()
-            ),
-            $this->mergeWhen($this->message->isImage(),
-                fn () => $this->linksForImage()
-            ),
+            $this->merge(fn () => $this->message->getResourceData()),
             $this->mergeWhen($this->addRelatedItems,
                 fn () => $this->addReplyToMessage()
             ),
@@ -142,17 +131,4 @@ class MessageResource extends JsonResource
         ))->resolve();
     }
 
-    /**
-     * @return array
-     */
-    public function linksForImage(): array
-    {
-        return [
-            'image' => [
-                'sm' => $this->message->getImageViewRoute('sm'),
-                'md' => $this->message->getImageViewRoute('md'),
-                'lg' => $this->message->getImageViewRoute('lg'),
-            ],
-        ];
-    }
 }

--- a/src/MessageTypes/Audio.php
+++ b/src/MessageTypes/Audio.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace RTippin\Messenger\MessageTypes;
+
+use RTippin\Messenger\Models\Message;
+
+class Audio extends Base
+{
+    protected int $code = 3;
+
+    protected string $verbose = 'AUDIO_MESSAGE';
+
+    public function getResourceData(Message $message): ?array
+    {
+        return ['audio' => $message->getAudioDownloadRoute()];
+    }
+}

--- a/src/MessageTypes/Base.php
+++ b/src/MessageTypes/Base.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace RTippin\Messenger\MessageTypes;
+
+use RTippin\Messenger\Contracts\MessageTypeProvider;
+use RTippin\Messenger\Models\Message;
+
+abstract class Base implements MessageTypeProvider
+{
+    protected bool $isSystem = false;
+
+    protected string $verbose = 'NOT_IMPLEMENTED';
+
+    protected int $code = -1;
+
+    public function isSystemType(): bool
+    {
+        return $this->isSystem;
+    }
+
+    public function getVerbose(): string
+    {
+        return $this->verbose;
+    }
+
+    public function getCode(): int
+    {
+        return $this->code;
+    }
+
+    public function getResourceData(Message $message): ?array
+    {
+        return [];
+    }
+}

--- a/src/MessageTypes/Document.php
+++ b/src/MessageTypes/Document.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace RTippin\Messenger\MessageTypes;
+
+use RTippin\Messenger\Models\Message;
+
+class Document extends Base
+{
+    protected int $code = 2;
+
+    protected string $verbose = 'DOCUMENT_MESSAGE';
+
+    public function getResourceData(Message $message): ?array
+    {
+        return ['document' => $message->getDocumentDownloadRoute()];
+    }
+}

--- a/src/MessageTypes/Image.php
+++ b/src/MessageTypes/Image.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace RTippin\Messenger\MessageTypes;
+
+use RTippin\Messenger\Models\Message;
+
+class Image extends Base
+{
+    protected int $code = 1;
+
+    protected string $verbose = 'IMAGE_MESSAGE';
+
+    public function getResourceData(Message $message): ?array
+    {
+        return [
+            'image' => [
+                'sm' => $message->getImageViewRoute('sm'),
+                'md' => $message->getImageViewRoute('md'),
+                'lg' => $message->getImageViewRoute('lg'),
+            ],
+        ];
+    }
+}

--- a/src/MessageTypes/Message.php
+++ b/src/MessageTypes/Message.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace RTippin\Messenger\MessageTypes;
+
+class Message extends Base
+{
+    protected int $code = 0;
+
+    protected string $verbose = 'MESSAGE';
+}

--- a/src/MessageTypes/System.php
+++ b/src/MessageTypes/System.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace RTippin\Messenger\MessageTypes;
+
+class System extends Base
+{
+    protected bool $isSystem = true;
+
+    public function __construct(
+        int $code = null,
+        string $verbose = null,
+    )
+    {
+        $this->code = $code ?? $this->code;
+        $this->verbose = $verbose ?? $this->verbose;
+    }
+
+}

--- a/src/MessageTypes/System.php
+++ b/src/MessageTypes/System.php
@@ -9,10 +9,8 @@ class System extends Base
     public function __construct(
         int $code = null,
         string $verbose = null,
-    )
-    {
+    ) {
         $this->code = $code ?? $this->code;
         $this->verbose = $verbose ?? $this->verbose;
     }
-
 }

--- a/src/MessageTypes/Video.php
+++ b/src/MessageTypes/Video.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace RTippin\Messenger\MessageTypes;
+
+use RTippin\Messenger\Models\Message;
+
+class Video extends Base
+{
+    protected int $code = 4;
+
+    protected string $verbose = 'VIDEO_MESSAGE';
+
+    public function getResourceData(Message $message): ?array
+    {
+        return ['video' => $message->getVideoDownloadRoute()];
+    }
+}

--- a/src/MessengerServiceProvider.php
+++ b/src/MessengerServiceProvider.php
@@ -57,7 +57,7 @@ class MessengerServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        $this->mergeConfigFrom(__DIR__ . '/../config/messenger.php', 'messenger');
+        $this->mergeConfigFrom(__DIR__.'/../config/messenger.php', 'messenger');
 
         $this->app->singleton(Messenger::class, Messenger::class);
         $this->app->singleton(MessengerTypes::class, MessengerTypes::class);
@@ -67,7 +67,7 @@ class MessengerServiceProvider extends ServiceProvider
         $this->app->bind(MessengerComposer::class, MessengerComposer::class);
         $this->app->bind(BroadcastDriver::class, BroadcastBroker::class);
         $this->app->bind(VideoDriver::class, NullVideoBroker::class);
-        $this->app->extend(ExceptionHandler::class, fn(ExceptionHandler $handler) => new Handler($handler));
+        $this->app->extend(ExceptionHandler::class, fn (ExceptionHandler $handler) => new Handler($handler));
         $this->app->alias(Messenger::class, 'messenger');
         $this->app->alias(MessengerTypes::class, 'messenger-types');
         $this->app->alias(MessengerBots::class, 'messenger-bots');
@@ -127,18 +127,18 @@ class MessengerServiceProvider extends ServiceProvider
             PurgeVideosCommand::class,
         ]);
 
-        $this->loadMigrationsFrom(__DIR__ . '/../database/migrations');
+        $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
 
         $this->publishes([
-            __DIR__ . '/../config/messenger.php' => config_path('messenger.php'),
+            __DIR__.'/../config/messenger.php' => config_path('messenger.php'),
         ], 'messenger.config');
 
         $this->publishes([
-            __DIR__ . '/../stubs/MessengerServiceProvider.stub' => app_path('Providers/MessengerServiceProvider.php'),
+            __DIR__.'/../stubs/MessengerServiceProvider.stub' => app_path('Providers/MessengerServiceProvider.php'),
         ], 'messenger.provider');
 
         $this->publishes([
-            __DIR__ . '/../database/migrations' => database_path('migrations'),
+            __DIR__.'/../database/migrations' => database_path('migrations'),
         ], 'messenger.migrations');
     }
 

--- a/src/MessengerTypes.php
+++ b/src/MessengerTypes.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace RTippin\Messenger;
+
+use Illuminate\Support\Collection;
+use InvalidArgumentException;
+use RTippin\Messenger\Contracts\MessageTypeProvider;
+
+class MessengerTypes
+{
+
+    /**
+     * @var Collection|MessageTypeProvider[]
+     */
+    private Collection $messageTypes;
+
+    /**
+     * @var Collection|int[]
+     */
+    private Collection $verboseIndex;
+
+
+    /**
+     * Messenger constructor.
+     */
+    public function __construct()
+    {
+        $this->messageTypes = Collection::make();
+        $this->verboseIndex = Collection::make();
+    }
+
+    /**
+     * Set all providers we want to use in this messenger system.
+     *
+     * @param array $messageTypes
+     * @param bool $overwrite
+     * @return void
+     */
+    public function registerProviders(array $messageTypes, bool $overwrite = false): void
+    {
+        if ($overwrite) {
+            $this->messageTypes = Collection::make();
+            $this->verboseIndex = Collection::make();
+        }
+
+        foreach ($messageTypes as $type) {
+            if (!is_subclass_of($type, MessageTypeProvider::class)) {
+                throw new InvalidArgumentException("The given provider { $type } must implement the interface " . MessageTypeProvider::class);
+            }
+
+            if (is_string($type)) {
+                $instance = new $type;
+            } else {
+                $instance = $type;
+            }
+
+            $this->messageTypes[$instance->getCode()] = $instance;
+            $this->verboseIndex[$instance->getVerbose()] = $instance->getCode();
+        }
+
+//        dump($this->verboseIndex->toArray());
+    }
+
+
+    public function getMessageTypes()
+    {
+        return $this->messageTypes;
+    }
+
+    public function code(string $type)
+    {
+        return $this->verboseIndex[$type]
+            ?? throw new InvalidArgumentException('Invalid type specified: ' . $type);
+    }
+
+    public function getMessageType(string $type): ?MessageTypeProvider
+    {
+        return $this->messageTypes->get($type);
+    }
+
+    public function getSystemTypes(): array
+    {
+        return $this->getSystemTypesProviders()
+            ->map(fn(MessageTypeProvider $t) => $t->getCode())
+            ->toArray();
+    }
+
+    public function getSystemTypesProviders()
+    {
+        return $this->messageTypes->filter(fn(MessageTypeProvider $mtp) => $mtp->isSystemType());
+    }
+
+    public function getNonSystemTypes(): array
+    {
+        return $this->getNonSystemTypesProviders()
+            ->map(fn(MessageTypeProvider $t) => $t->getCode())
+            ->toArray();
+    }
+
+    public function getNonSystemTypesProviders(): Collection
+    {
+        return $this->messageTypes
+            ->filter(fn(MessageTypeProvider $mtp) => !$mtp->isSystemType());
+    }
+}

--- a/src/MessengerTypes.php
+++ b/src/MessengerTypes.php
@@ -8,7 +8,6 @@ use RTippin\Messenger\Contracts\MessageTypeProvider;
 
 class MessengerTypes
 {
-
     /**
      * @var Collection|MessageTypeProvider[]
      */
@@ -18,7 +17,6 @@ class MessengerTypes
      * @var Collection|int[]
      */
     private Collection $verboseIndex;
-
 
     /**
      * Messenger constructor.
@@ -32,8 +30,8 @@ class MessengerTypes
     /**
      * Set all providers we want to use in this messenger system.
      *
-     * @param array $messageTypes
-     * @param bool $overwrite
+     * @param  array  $messageTypes
+     * @param  bool  $overwrite
      * @return void
      */
     public function registerProviders(array $messageTypes, bool $overwrite = false): void
@@ -44,8 +42,8 @@ class MessengerTypes
         }
 
         foreach ($messageTypes as $type) {
-            if (!is_subclass_of($type, MessageTypeProvider::class)) {
-                throw new InvalidArgumentException("The given provider { $type } must implement the interface " . MessageTypeProvider::class);
+            if (! is_subclass_of($type, MessageTypeProvider::class)) {
+                throw new InvalidArgumentException("The given provider { $type } must implement the interface ".MessageTypeProvider::class);
             }
 
             if (is_string($type)) {
@@ -61,7 +59,6 @@ class MessengerTypes
 //        dump($this->verboseIndex->toArray());
     }
 
-
     public function getMessageTypes()
     {
         return $this->messageTypes;
@@ -70,7 +67,7 @@ class MessengerTypes
     public function code(string $type)
     {
         return $this->verboseIndex[$type]
-            ?? throw new InvalidArgumentException('Invalid type specified: ' . $type);
+            ?? throw new InvalidArgumentException('Invalid type specified: '.$type);
     }
 
     public function getMessageType(string $type): ?MessageTypeProvider
@@ -81,25 +78,25 @@ class MessengerTypes
     public function getSystemTypes(): array
     {
         return $this->getSystemTypesProviders()
-            ->map(fn(MessageTypeProvider $t) => $t->getCode())
+            ->map(fn (MessageTypeProvider $t) => $t->getCode())
             ->toArray();
     }
 
     public function getSystemTypesProviders()
     {
-        return $this->messageTypes->filter(fn(MessageTypeProvider $mtp) => $mtp->isSystemType());
+        return $this->messageTypes->filter(fn (MessageTypeProvider $mtp) => $mtp->isSystemType());
     }
 
     public function getNonSystemTypes(): array
     {
         return $this->getNonSystemTypesProviders()
-            ->map(fn(MessageTypeProvider $t) => $t->getCode())
+            ->map(fn (MessageTypeProvider $t) => $t->getCode())
             ->toArray();
     }
 
     public function getNonSystemTypesProviders(): Collection
     {
         return $this->messageTypes
-            ->filter(fn(MessageTypeProvider $mtp) => !$mtp->isSystemType());
+            ->filter(fn (MessageTypeProvider $mtp) => ! $mtp->isSystemType());
     }
 }

--- a/src/Models/Message.php
+++ b/src/Models/Message.php
@@ -533,12 +533,14 @@ class Message extends Model implements Ownerable
         return $this->temporaryId;
     }
 
-    public function getMessageTypeProvider(): MessageTypeProvider {
+    public function getMessageTypeProvider(): MessageTypeProvider
+    {
 //        dump($this->type);
         return MessengerTypes::getMessageType($this->type);
     }
 
-    public function getResourceData() {
+    public function getResourceData()
+    {
         return $this->getMessageTypeProvider()->getResourceData($this);
     }
 

--- a/src/Models/Thread.php
+++ b/src/Models/Thread.php
@@ -15,6 +15,7 @@ use RTippin\Messenger\Contracts\HasPresenceChannel;
 use RTippin\Messenger\Contracts\MessengerProvider;
 use RTippin\Messenger\Database\Factories\ThreadFactory;
 use RTippin\Messenger\Facades\Messenger;
+use RTippin\Messenger\Facades\MessengerTypes;
 use RTippin\Messenger\Support\Helpers;
 use RTippin\Messenger\Traits\ScopesProvider;
 use RTippin\Messenger\Traits\Uuids;
@@ -236,7 +237,7 @@ class Thread extends Model implements HasPresenceChannel
     public function logs(): HasMany
     {
         return $this->hasMany(Message::class)
-            ->whereNotIn('type', Message::NonSystemTypes);
+            ->whereNotIn('type', MessengerTypes::getNonSystemTypes());
     }
 
     /**

--- a/src/Repositories/MessageTypeRepository.php
+++ b/src/Repositories/MessageTypeRepository.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace RTippin\Messenger\Repositories;
+
+class MessageTypeRepository
+{
+
+}

--- a/src/Repositories/MessageTypeRepository.php
+++ b/src/Repositories/MessageTypeRepository.php
@@ -4,5 +4,4 @@ namespace RTippin\Messenger\Repositories;
 
 class MessageTypeRepository
 {
-
 }

--- a/src/Support/MessageTransformer.php
+++ b/src/Support/MessageTransformer.php
@@ -6,6 +6,7 @@ use Exception;
 use Illuminate\Support\Collection;
 use RTippin\Messenger\Contracts\MessengerProvider;
 use RTippin\Messenger\Facades\Messenger;
+use RTippin\Messenger\Facades\MessengerTypes;
 use RTippin\Messenger\Models\Call;
 use RTippin\Messenger\Models\GhostUser;
 use RTippin\Messenger\Models\Message;
@@ -71,7 +72,7 @@ class MessageTransformer
             $thread,
             $provider,
             'joined',
-            Message::PARTICIPANT_JOINED_WITH_INVITE,
+            MessengerTypes::code('PARTICIPANT_JOINED_WITH_INVITE'),
         ];
     }
 
@@ -89,7 +90,7 @@ class MessageTransformer
             $thread,
             $provider,
             Collection::make(['call_id' => $call->id])->toJson(),
-            Message::VIDEO_CALL,
+            MessengerTypes::code('VIDEO_CALL'),
         ];
     }
 
@@ -104,7 +105,7 @@ class MessageTransformer
             $thread,
             $provider,
             'updated the avatar',
-            Message::GROUP_AVATAR_CHANGED,
+            MessengerTypes::code('GROUP_AVATAR_CHANGED'),
         ];
     }
 
@@ -119,7 +120,7 @@ class MessageTransformer
             $thread,
             $provider,
             ($thread->isGroup() ? 'archived the group' : 'archived the conversation'),
-            Message::THREAD_ARCHIVED,
+            MessengerTypes::code('THREAD_ARCHIVED'),
         ];
     }
 
@@ -137,7 +138,7 @@ class MessageTransformer
             $thread,
             $provider,
             "created $subject",
-            Message::GROUP_CREATED,
+            MessengerTypes::code('GROUP_CREATED'),
         ];
     }
 
@@ -155,7 +156,7 @@ class MessageTransformer
             $thread,
             $provider,
             "renamed the group to $subject",
-            Message::GROUP_RENAMED,
+            MessengerTypes::code('GROUP_RENAMED'),
         ];
     }
 
@@ -173,7 +174,7 @@ class MessageTransformer
             $thread,
             $provider,
             self::generateParticipantJson($participant),
-            Message::DEMOTED_ADMIN,
+            MessengerTypes::code('DEMOTED_ADMIN'),
         ];
     }
 
@@ -191,7 +192,7 @@ class MessageTransformer
             $thread,
             $provider,
             self::generateParticipantJson($participant),
-            Message::PROMOTED_ADMIN,
+            MessengerTypes::code('PROMOTED_ADMIN'),
         ];
     }
 
@@ -206,7 +207,7 @@ class MessageTransformer
             $thread,
             $provider,
             'left',
-            Message::PARTICIPANT_LEFT_GROUP,
+            MessengerTypes::code('PARTICIPANT_LEFT_GROUP'),
         ];
     }
 
@@ -224,7 +225,7 @@ class MessageTransformer
             $thread,
             $provider,
             self::generateParticipantJson($participant),
-            Message::PARTICIPANT_REMOVED,
+            MessengerTypes::code('PARTICIPANT_REMOVED'),
         ];
     }
 
@@ -247,7 +248,7 @@ class MessageTransformer
             $thread,
             $provider,
             $body,
-            Message::PARTICIPANTS_ADDED,
+            MessengerTypes::code('PARTICIPANTS_ADDED'),
         ];
     }
 
@@ -265,7 +266,7 @@ class MessageTransformer
             $thread,
             $provider,
             "added the BOT - $botName",
-            Message::BOT_ADDED,
+            MessengerTypes::code('BOT_ADDED'),
         ];
     }
 
@@ -285,7 +286,7 @@ class MessageTransformer
             $thread,
             $provider,
             "renamed the BOT ( $oldName ) to $botName",
-            Message::BOT_RENAMED,
+            MessengerTypes::code('BOT_RENAMED'),
         ];
     }
 
@@ -303,7 +304,7 @@ class MessageTransformer
             $thread,
             $provider,
             "updated the avatar for the BOT - $botName",
-            Message::BOT_AVATAR_CHANGED,
+            MessengerTypes::code('BOT_AVATAR_CHANGED'),
         ];
     }
 
@@ -321,7 +322,7 @@ class MessageTransformer
             $thread,
             $provider,
             "removed the BOT - $botName",
-            Message::BOT_REMOVED,
+            MessengerTypes::code('BOT_REMOVED'),
         ];
     }
 
@@ -339,7 +340,7 @@ class MessageTransformer
             $thread,
             $provider,
             "installed the BOT - $packageName",
-            Message::BOT_PACKAGE_INSTALLED,
+            MessengerTypes::code('BOT_PACKAGE_INSTALLED'),
         ];
     }
 

--- a/tests/Actions/StoreSystemMessageTest.php
+++ b/tests/Actions/StoreSystemMessageTest.php
@@ -9,7 +9,7 @@ use RTippin\Messenger\Actions\Messages\StoreSystemMessage;
 use RTippin\Messenger\Broadcasting\NewMessageBroadcast;
 use RTippin\Messenger\Events\NewMessageEvent;
 use RTippin\Messenger\Facades\Messenger;
-use RTippin\Messenger\Models\Message;
+use RTippin\Messenger\Facades\MessengerTypes;
 use RTippin\Messenger\Models\Thread;
 use RTippin\Messenger\Tests\FeatureTestCase;
 
@@ -20,11 +20,11 @@ class StoreSystemMessageTest extends FeatureTestCase
     {
         $thread = Thread::factory()->group()->create();
 
-        app(StoreSystemMessage::class)->execute($thread, $this->tippin, 'system', Message::GROUP_CREATED);
+        app(StoreSystemMessage::class)->execute($thread, $this->tippin, 'system', MessengerTypes::code('GROUP_CREATED'));
 
         $this->assertDatabaseHas('messages', [
             'thread_id' => $thread->id,
-            'type' => Message::GROUP_CREATED,
+            'type' => MessengerTypes::code('GROUP_CREATED'),
             'body' => 'system',
         ]);
     }
@@ -36,7 +36,7 @@ class StoreSystemMessageTest extends FeatureTestCase
         $updated = now()->addMinutes(5)->format('Y-m-d H:i:s.u');
         Carbon::setTestNow($updated);
 
-        app(StoreSystemMessage::class)->execute($thread, $this->tippin, 'system', Message::GROUP_CREATED);
+        app(StoreSystemMessage::class)->execute($thread, $this->tippin, 'system', MessengerTypes::code('GROUP_CREATED'));
 
         $this->assertDatabaseHas('threads', [
             'id' => $thread->id,
@@ -55,7 +55,7 @@ class StoreSystemMessageTest extends FeatureTestCase
         Messenger::setSystemMessages(false);
         $thread = Thread::factory()->group()->create();
 
-        app(StoreSystemMessage::class)->execute($thread, $this->tippin, 'system', Message::GROUP_CREATED);
+        app(StoreSystemMessage::class)->execute($thread, $this->tippin, 'system', MessengerTypes::code('GROUP_CREATED'));
 
         $this->assertDatabaseCount('messages', 0);
         Event::assertNotDispatched(NewMessageBroadcast::class);
@@ -72,7 +72,7 @@ class StoreSystemMessageTest extends FeatureTestCase
         ]);
         $thread = $this->createPrivateThread($this->tippin, $this->doe);
 
-        app(StoreSystemMessage::class)->execute($thread, $this->tippin, 'system', Message::GROUP_CREATED);
+        app(StoreSystemMessage::class)->execute($thread, $this->tippin, 'system', MessengerTypes::code('GROUP_CREATED'));
 
         Event::assertDispatched(function (NewMessageBroadcast $event) use ($thread) {
             $this->assertContains('private-messenger.user.'.$this->doe->getKey(), $event->broadcastOn());
@@ -94,6 +94,8 @@ class StoreSystemMessageTest extends FeatureTestCase
      */
     public function it_stores_message_type_using_description($type)
     {
+        $type = MessengerTypes::code($type);
+
         $thread = Thread::factory()->group()->create();
 
         app(StoreSystemMessage::class)->execute($thread, $this->tippin, 'system', $type);
@@ -107,22 +109,22 @@ class StoreSystemMessageTest extends FeatureTestCase
     public function messageTypes(): array
     {
         return [
-            [Message::PARTICIPANT_JOINED_WITH_INVITE],
-            [Message::VIDEO_CALL],
-            [Message::GROUP_AVATAR_CHANGED],
-            [Message::THREAD_ARCHIVED],
-            [Message::GROUP_CREATED],
-            [Message::GROUP_RENAMED],
-            [Message::DEMOTED_ADMIN],
-            [Message::PROMOTED_ADMIN],
-            [Message::PARTICIPANT_LEFT_GROUP],
-            [Message::PARTICIPANT_REMOVED],
-            [Message::PARTICIPANTS_ADDED],
-            [Message::BOT_ADDED],
-            [Message::BOT_RENAMED],
-            [Message::BOT_AVATAR_CHANGED],
-            [Message::BOT_REMOVED],
-            [Message::BOT_PACKAGE_INSTALLED],
+            ['PARTICIPANT_JOINED_WITH_INVITE'],
+            ['VIDEO_CALL'],
+            ['GROUP_AVATAR_CHANGED'],
+            ['THREAD_ARCHIVED'],
+            ['GROUP_CREATED'],
+            ['GROUP_RENAMED'],
+            ['DEMOTED_ADMIN'],
+            ['PROMOTED_ADMIN'],
+            ['PARTICIPANT_LEFT_GROUP'],
+            ['PARTICIPANT_REMOVED'],
+            ['PARTICIPANTS_ADDED'],
+            ['BOT_ADDED'],
+            ['BOT_RENAMED'],
+            ['BOT_AVATAR_CHANGED'],
+            ['BOT_REMOVED'],
+            ['BOT_PACKAGE_INSTALLED'],
         ];
     }
 }

--- a/tests/Http/VideoMessageTest.php
+++ b/tests/Http/VideoMessageTest.php
@@ -4,6 +4,7 @@ namespace RTippin\Messenger\Tests\Http;
 
 use Illuminate\Http\UploadedFile;
 use RTippin\Messenger\Facades\Messenger;
+use RTippin\Messenger\Facades\MessengerTypes;
 use RTippin\Messenger\Models\Message;
 use RTippin\Messenger\Models\Participant;
 use RTippin\Messenger\Models\Thread;
@@ -64,7 +65,7 @@ class VideoMessageTest extends HttpTestCase
             ->assertJson([
                 'thread_id' => $thread->id,
                 'temporary_id' => '123-456-789',
-                'type' => Message::VIDEO_MESSAGE,
+                'type' => MessengerTypes::code('VIDEO_MESSAGE'),
                 'type_verbose' => 'VIDEO_MESSAGE',
             ]);
     }

--- a/tests/Models/MessageTest.php
+++ b/tests/Models/MessageTest.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
 use RTippin\Messenger\Contracts\MessengerProvider;
 use RTippin\Messenger\Facades\Messenger;
+use RTippin\Messenger\Facades\MessengerTypes;
 use RTippin\Messenger\Models\Bot;
 use RTippin\Messenger\Models\GhostUser;
 use RTippin\Messenger\Models\Message;
@@ -347,7 +348,7 @@ class MessageTest extends FeatureTestCase
     {
         $message = Message::factory()->for(
             Thread::factory()->create()
-        )->owner($this->tippin)->system(Message::GROUP_CREATED)->create();
+        )->owner($this->tippin)->system(MessengerTypes::code('GROUP_CREATED'))->create();
 
         $this->assertTrue($message->isSystemMessage());
         $this->assertFalse($message->notSystemMessage());

--- a/tests/Support/MessageTransformerTest.php
+++ b/tests/Support/MessageTransformerTest.php
@@ -3,6 +3,7 @@
 namespace RTippin\Messenger\Tests\Support;
 
 use RTippin\Messenger\Facades\Messenger;
+use RTippin\Messenger\Facades\MessengerTypes;
 use RTippin\Messenger\Models\Call;
 use RTippin\Messenger\Models\GhostUser;
 use RTippin\Messenger\Models\Message;
@@ -24,7 +25,7 @@ class MessageTransformerTest extends FeatureTestCase
             $thread,
             $this->tippin,
             'joined',
-            Message::PARTICIPANT_JOINED_WITH_INVITE,
+            MessengerTypes::code('PARTICIPANT_JOINED_WITH_INVITE'),
         ], MessageTransformer::makeJoinedWithInvite($thread, $this->tippin));
     }
 
@@ -38,7 +39,7 @@ class MessageTransformerTest extends FeatureTestCase
             $thread,
             $this->tippin,
             '{"call_id":"'.$call->id.'"}',
-            Message::VIDEO_CALL,
+            MessengerTypes::code('VIDEO_CALL'),
         ], MessageTransformer::makeVideoCall($thread, $this->tippin, $call));
     }
 
@@ -51,7 +52,7 @@ class MessageTransformerTest extends FeatureTestCase
             $thread,
             $this->tippin,
             'updated the avatar',
-            Message::GROUP_AVATAR_CHANGED,
+            MessengerTypes::code('GROUP_AVATAR_CHANGED'),
         ], MessageTransformer::makeGroupAvatarChanged($thread, $this->tippin));
     }
 
@@ -64,7 +65,7 @@ class MessageTransformerTest extends FeatureTestCase
             $thread,
             $this->tippin,
             'archived the conversation',
-            Message::THREAD_ARCHIVED,
+            MessengerTypes::code('THREAD_ARCHIVED'),
         ], MessageTransformer::makeThreadArchived($thread, $this->tippin));
     }
 
@@ -77,7 +78,7 @@ class MessageTransformerTest extends FeatureTestCase
             $thread,
             $this->tippin,
             'archived the group',
-            Message::THREAD_ARCHIVED,
+            MessengerTypes::code('THREAD_ARCHIVED'),
         ], MessageTransformer::makeThreadArchived($thread, $this->tippin));
     }
 
@@ -90,7 +91,7 @@ class MessageTransformerTest extends FeatureTestCase
             $thread,
             $this->tippin,
             'created Group Name',
-            Message::GROUP_CREATED,
+            MessengerTypes::code('GROUP_CREATED'),
         ], MessageTransformer::makeGroupCreated($thread, $this->tippin, 'Group Name'));
     }
 
@@ -103,7 +104,7 @@ class MessageTransformerTest extends FeatureTestCase
             $thread,
             $this->tippin,
             'renamed the group to Renamed',
-            Message::GROUP_RENAMED,
+            MessengerTypes::code('GROUP_RENAMED'),
         ], MessageTransformer::makeGroupRenamed($thread, $this->tippin, 'Renamed'));
     }
 
@@ -118,7 +119,7 @@ class MessageTransformerTest extends FeatureTestCase
 
         $this->assertSame($thread, $make[0]);
         $this->assertSame($this->tippin, $make[1]);
-        $this->assertSame(Message::DEMOTED_ADMIN, $make[3]);
+        $this->assertSame(MessengerTypes::code('DEMOTED_ADMIN'), $make[3]);
         $this->assertSame($json, [
             'owner_id' => $this->tippin->getKey(),
             'owner_type' => $this->tippin->getMorphClass(),
@@ -136,7 +137,7 @@ class MessageTransformerTest extends FeatureTestCase
 
         $this->assertSame($thread, $make[0]);
         $this->assertSame($this->tippin, $make[1]);
-        $this->assertSame(Message::PROMOTED_ADMIN, $make[3]);
+        $this->assertSame(MessengerTypes::code('PROMOTED_ADMIN'), $make[3]);
         $this->assertSame($json, [
             'owner_id' => $this->tippin->getKey(),
             'owner_type' => $this->tippin->getMorphClass(),
@@ -152,7 +153,7 @@ class MessageTransformerTest extends FeatureTestCase
             $thread,
             $this->tippin,
             'left',
-            Message::PARTICIPANT_LEFT_GROUP,
+            MessengerTypes::code('PARTICIPANT_LEFT_GROUP'),
         ], MessageTransformer::makeGroupLeft($thread, $this->tippin));
     }
 
@@ -167,7 +168,7 @@ class MessageTransformerTest extends FeatureTestCase
 
         $this->assertSame($thread, $make[0]);
         $this->assertSame($this->tippin, $make[1]);
-        $this->assertSame(Message::PARTICIPANT_REMOVED, $make[3]);
+        $this->assertSame(MessengerTypes::code('PARTICIPANT_REMOVED'), $make[3]);
         $this->assertSame($json, [
             'owner_id' => $this->tippin->getKey(),
             'owner_type' => $this->tippin->getMorphClass(),
@@ -186,7 +187,7 @@ class MessageTransformerTest extends FeatureTestCase
 
         $this->assertSame($thread, $make[0]);
         $this->assertSame($this->tippin, $make[1]);
-        $this->assertSame(Message::PARTICIPANTS_ADDED, $make[3]);
+        $this->assertSame(MessengerTypes::code('PARTICIPANTS_ADDED'), $make[3]);
         $this->assertSame($json, [
             [
                 'owner_id' => $this->tippin->getKey(),
@@ -208,7 +209,7 @@ class MessageTransformerTest extends FeatureTestCase
             $thread,
             $this->tippin,
             'added the BOT - Test Bot',
-            Message::BOT_ADDED,
+            MessengerTypes::code('BOT_ADDED'),
         ], MessageTransformer::makeBotAdded($thread, $this->tippin, 'Test Bot'));
     }
 
@@ -221,7 +222,7 @@ class MessageTransformerTest extends FeatureTestCase
             $thread,
             $this->tippin,
             'renamed the BOT ( Test Bot ) to Renamed',
-            Message::BOT_RENAMED,
+            MessengerTypes::code('BOT_RENAMED'),
         ], MessageTransformer::makeBotRenamed($thread, $this->tippin, 'Test Bot', 'Renamed'));
     }
 
@@ -234,7 +235,7 @@ class MessageTransformerTest extends FeatureTestCase
             $thread,
             $this->tippin,
             'updated the avatar for the BOT - Test Bot',
-            Message::BOT_AVATAR_CHANGED,
+            MessengerTypes::code('BOT_AVATAR_CHANGED'),
         ], MessageTransformer::makeBotAvatarChanged($thread, $this->tippin, 'Test Bot'));
     }
 
@@ -247,7 +248,7 @@ class MessageTransformerTest extends FeatureTestCase
             $thread,
             $this->tippin,
             'removed the BOT - Test Bot',
-            Message::BOT_REMOVED,
+            MessengerTypes::code('BOT_REMOVED'),
         ], MessageTransformer::makeBotRemoved($thread, $this->tippin, 'Test Bot'));
     }
 
@@ -260,7 +261,7 @@ class MessageTransformerTest extends FeatureTestCase
             $thread,
             $this->tippin,
             'installed the BOT - Test Bot',
-            Message::BOT_PACKAGE_INSTALLED,
+            MessengerTypes::code('BOT_PACKAGE_INSTALLED'),
         ], MessageTransformer::makeBotPackageInstalled($thread, $this->tippin, 'Test Bot'));
     }
 
@@ -361,7 +362,7 @@ class MessageTransformerTest extends FeatureTestCase
             ->for($thread)
             ->owner($this->tippin)
             ->create([
-                'type' => Message::PARTICIPANT_JOINED_WITH_INVITE,
+                'type' => MessengerTypes::code('PARTICIPANT_JOINED_WITH_INVITE'),
                 'body' => MessageTransformer::makeJoinedWithInvite($thread, $this->tippin)[2],
             ]);
 
@@ -377,7 +378,7 @@ class MessageTransformerTest extends FeatureTestCase
             ->for($thread)
             ->owner($this->tippin)
             ->create([
-                'type' => Message::VIDEO_CALL,
+                'type' => MessengerTypes::code('VIDEO_CALL'),
                 'body' => MessageTransformer::makeVideoCall($thread, $this->tippin, $call)[2],
             ]);
 
@@ -392,7 +393,7 @@ class MessageTransformerTest extends FeatureTestCase
             ->for($thread)
             ->owner($this->tippin)
             ->create([
-                'type' => Message::VIDEO_CALL,
+                'type' => MessengerTypes::code('VIDEO_CALL'),
                 'body' => '',
             ]);
 
@@ -408,7 +409,7 @@ class MessageTransformerTest extends FeatureTestCase
             ->for($thread)
             ->owner($this->tippin)
             ->create([
-                'type' => Message::VIDEO_CALL,
+                'type' => MessengerTypes::code('VIDEO_CALL'),
                 'body' => MessageTransformer::makeVideoCall($thread, $this->tippin, $call)[2],
             ]);
 
@@ -424,7 +425,7 @@ class MessageTransformerTest extends FeatureTestCase
             ->for($thread)
             ->owner($this->tippin)
             ->create([
-                'type' => Message::VIDEO_CALL,
+                'type' => MessengerTypes::code('VIDEO_CALL'),
                 'body' => MessageTransformer::makeVideoCall($thread, $this->tippin, $call)[2],
             ]);
 
@@ -440,7 +441,7 @@ class MessageTransformerTest extends FeatureTestCase
             ->for($thread)
             ->owner($this->tippin)
             ->create([
-                'type' => Message::VIDEO_CALL,
+                'type' => MessengerTypes::code('VIDEO_CALL'),
                 'body' => MessageTransformer::makeVideoCall($thread, $this->tippin, $call)[2],
             ]);
         $this->doe->delete();
@@ -457,7 +458,7 @@ class MessageTransformerTest extends FeatureTestCase
             ->for($thread)
             ->owner($this->doe)
             ->create([
-                'type' => Message::VIDEO_CALL,
+                'type' => MessengerTypes::code('VIDEO_CALL'),
                 'body' => MessageTransformer::makeVideoCall($thread, $this->tippin, $call)[2],
             ]);
         $this->doe->delete();
@@ -474,7 +475,7 @@ class MessageTransformerTest extends FeatureTestCase
             ->for($thread)
             ->owner($this->tippin)
             ->create([
-                'type' => Message::VIDEO_CALL,
+                'type' => MessengerTypes::code('VIDEO_CALL'),
                 'body' => MessageTransformer::makeVideoCall($thread, $this->tippin, $call)[2],
             ]);
 
@@ -490,7 +491,7 @@ class MessageTransformerTest extends FeatureTestCase
             ->for($thread)
             ->owner($this->tippin)
             ->create([
-                'type' => Message::VIDEO_CALL,
+                'type' => MessengerTypes::code('VIDEO_CALL'),
                 'body' => MessageTransformer::makeVideoCall($thread, $this->tippin, $call)[2],
             ]);
 
@@ -513,7 +514,7 @@ class MessageTransformerTest extends FeatureTestCase
             ->for($thread)
             ->owner($this->tippin)
             ->create([
-                'type' => Message::VIDEO_CALL,
+                'type' => MessengerTypes::code('VIDEO_CALL'),
                 'body' => MessageTransformer::makeVideoCall($thread, $this->tippin, $call)[2],
             ]);
 
@@ -538,7 +539,7 @@ class MessageTransformerTest extends FeatureTestCase
             ->for($thread)
             ->owner($this->tippin)
             ->create([
-                'type' => Message::VIDEO_CALL,
+                'type' => MessengerTypes::code('VIDEO_CALL'),
                 'body' => MessageTransformer::makeVideoCall($thread, $this->tippin, $call)[2],
             ]);
 
@@ -553,7 +554,7 @@ class MessageTransformerTest extends FeatureTestCase
             ->for($thread)
             ->owner($this->tippin)
             ->create([
-                'type' => Message::GROUP_AVATAR_CHANGED,
+                'type' => MessengerTypes::code('GROUP_AVATAR_CHANGED'),
                 'body' => MessageTransformer::makeGroupAvatarChanged($thread, $this->tippin)[2],
             ]);
 
@@ -568,7 +569,7 @@ class MessageTransformerTest extends FeatureTestCase
             ->for($thread)
             ->owner($this->tippin)
             ->create([
-                'type' => Message::THREAD_ARCHIVED,
+                'type' => MessengerTypes::code('THREAD_ARCHIVED'),
                 'body' => MessageTransformer::makeThreadArchived($thread, $this->tippin)[2],
             ]);
 
@@ -583,7 +584,7 @@ class MessageTransformerTest extends FeatureTestCase
             ->for($thread)
             ->owner($this->tippin)
             ->create([
-                'type' => Message::THREAD_ARCHIVED,
+                'type' => MessengerTypes::code('THREAD_ARCHIVED'),
                 'body' => MessageTransformer::makeThreadArchived($thread, $this->tippin)[2],
             ]);
 
@@ -598,7 +599,7 @@ class MessageTransformerTest extends FeatureTestCase
             ->for($thread)
             ->owner($this->tippin)
             ->create([
-                'type' => Message::GROUP_CREATED,
+                'type' => MessengerTypes::code('GROUP_CREATED'),
                 'body' => MessageTransformer::makeGroupCreated($thread, $this->tippin, 'Some Group')[2],
             ]);
 
@@ -613,7 +614,7 @@ class MessageTransformerTest extends FeatureTestCase
             ->for($thread)
             ->owner($this->tippin)
             ->create([
-                'type' => Message::GROUP_RENAMED,
+                'type' => MessengerTypes::code('GROUP_RENAMED'),
                 'body' => MessageTransformer::makeGroupRenamed($thread, $this->tippin, 'Some Group')[2],
             ]);
 
@@ -629,7 +630,7 @@ class MessageTransformerTest extends FeatureTestCase
             ->for($thread)
             ->owner($this->tippin)
             ->create([
-                'type' => Message::DEMOTED_ADMIN,
+                'type' => MessengerTypes::code('DEMOTED_ADMIN'),
                 'body' => MessageTransformer::makeParticipantDemoted($thread, $this->tippin, $participant)[2],
             ]);
 
@@ -644,7 +645,7 @@ class MessageTransformerTest extends FeatureTestCase
             ->for($thread)
             ->owner($this->tippin)
             ->create([
-                'type' => Message::DEMOTED_ADMIN,
+                'type' => MessengerTypes::code('DEMOTED_ADMIN'),
                 'body' => '',
             ]);
 
@@ -660,7 +661,7 @@ class MessageTransformerTest extends FeatureTestCase
             ->for($thread)
             ->owner($this->tippin)
             ->create([
-                'type' => Message::PROMOTED_ADMIN,
+                'type' => MessengerTypes::code('PROMOTED_ADMIN'),
                 'body' => MessageTransformer::makeParticipantPromoted($thread, $this->tippin, $participant)[2],
             ]);
 
@@ -675,7 +676,7 @@ class MessageTransformerTest extends FeatureTestCase
             ->for($thread)
             ->owner($this->tippin)
             ->create([
-                'type' => Message::PROMOTED_ADMIN,
+                'type' => MessengerTypes::code('PROMOTED_ADMIN'),
                 'body' => '',
             ]);
 
@@ -690,7 +691,7 @@ class MessageTransformerTest extends FeatureTestCase
             ->for($thread)
             ->owner($this->tippin)
             ->create([
-                'type' => Message::PARTICIPANT_LEFT_GROUP,
+                'type' => MessengerTypes::code('PARTICIPANT_LEFT_GROUP'),
                 'body' => MessageTransformer::makeGroupLeft($thread, $this->tippin)[2],
             ]);
 
@@ -706,7 +707,7 @@ class MessageTransformerTest extends FeatureTestCase
             ->for($thread)
             ->owner($this->tippin)
             ->create([
-                'type' => Message::PARTICIPANT_REMOVED,
+                'type' => MessengerTypes::code('PARTICIPANT_REMOVED'),
                 'body' => MessageTransformer::makeRemovedFromGroup($thread, $this->tippin, $participant)[2],
             ]);
 
@@ -721,7 +722,7 @@ class MessageTransformerTest extends FeatureTestCase
             ->for($thread)
             ->owner($this->tippin)
             ->create([
-                'type' => Message::PARTICIPANT_REMOVED,
+                'type' => MessengerTypes::code('PARTICIPANT_REMOVED'),
                 'body' => '',
             ]);
 
@@ -737,7 +738,7 @@ class MessageTransformerTest extends FeatureTestCase
             ->for($thread)
             ->owner($this->tippin)
             ->create([
-                'type' => Message::PARTICIPANTS_ADDED,
+                'type' => MessengerTypes::code('PARTICIPANTS_ADDED'),
                 'body' => MessageTransformer::makeParticipantsAdded($thread, $this->tippin, collect([$participant]))[2],
             ]);
 
@@ -752,7 +753,7 @@ class MessageTransformerTest extends FeatureTestCase
             ->for($thread)
             ->owner($this->tippin)
             ->create([
-                'type' => Message::PARTICIPANTS_ADDED,
+                'type' => MessengerTypes::code('PARTICIPANTS_ADDED'),
                 'body' => '',
             ]);
 
@@ -770,7 +771,7 @@ class MessageTransformerTest extends FeatureTestCase
             ->for($thread)
             ->owner($this->tippin)
             ->create([
-                'type' => Message::PARTICIPANTS_ADDED,
+                'type' => MessengerTypes::code('PARTICIPANTS_ADDED'),
                 'body' => MessageTransformer::makeParticipantsAdded($thread, $this->tippin, $participants)[2],
             ]);
 
@@ -788,7 +789,7 @@ class MessageTransformerTest extends FeatureTestCase
             ->for($thread)
             ->owner($this->tippin)
             ->create([
-                'type' => Message::PARTICIPANTS_ADDED,
+                'type' => MessengerTypes::code('PARTICIPANTS_ADDED'),
                 'body' => MessageTransformer::makeParticipantsAdded($thread, $this->tippin, $participants)[2],
             ]);
         $this->doe->delete();
@@ -808,7 +809,7 @@ class MessageTransformerTest extends FeatureTestCase
             ->for($thread)
             ->owner($this->tippin)
             ->create([
-                'type' => Message::PARTICIPANTS_ADDED,
+                'type' => MessengerTypes::code('PARTICIPANTS_ADDED'),
                 'body' => MessageTransformer::makeParticipantsAdded($thread, $this->tippin, $participants)[2],
             ]);
 
@@ -828,7 +829,7 @@ class MessageTransformerTest extends FeatureTestCase
             ->for($thread)
             ->owner($this->tippin)
             ->create([
-                'type' => Message::PARTICIPANTS_ADDED,
+                'type' => MessengerTypes::code('PARTICIPANTS_ADDED'),
                 'body' => MessageTransformer::makeParticipantsAdded($thread, $this->tippin, $participants)[2],
             ]);
 
@@ -850,7 +851,7 @@ class MessageTransformerTest extends FeatureTestCase
             ->for($thread)
             ->owner($this->tippin)
             ->create([
-                'type' => Message::PARTICIPANTS_ADDED,
+                'type' => MessengerTypes::code('PARTICIPANTS_ADDED'),
                 'body' => MessageTransformer::makeParticipantsAdded($thread, $this->tippin, $participants)[2],
             ]);
 
@@ -865,7 +866,7 @@ class MessageTransformerTest extends FeatureTestCase
             ->for($thread)
             ->owner($this->tippin)
             ->create([
-                'type' => Message::BOT_ADDED,
+                'type' => MessengerTypes::code('BOT_ADDED'),
                 'body' => MessageTransformer::makeBotAdded($thread, $this->tippin, 'Test Bot')[2],
             ]);
 
@@ -880,7 +881,7 @@ class MessageTransformerTest extends FeatureTestCase
             ->for($thread)
             ->owner($this->tippin)
             ->create([
-                'type' => Message::BOT_RENAMED,
+                'type' => MessengerTypes::code('BOT_RENAMED'),
                 'body' => MessageTransformer::makeBotRenamed($thread, $this->tippin, 'Test Bot', 'Renamed')[2],
             ]);
 
@@ -895,7 +896,7 @@ class MessageTransformerTest extends FeatureTestCase
             ->for($thread)
             ->owner($this->tippin)
             ->create([
-                'type' => Message::BOT_AVATAR_CHANGED,
+                'type' => MessengerTypes::code('BOT_AVATAR_CHANGED'),
                 'body' => MessageTransformer::makeBotAvatarChanged($thread, $this->tippin, 'Test Bot')[2],
             ]);
 
@@ -910,7 +911,7 @@ class MessageTransformerTest extends FeatureTestCase
             ->for($thread)
             ->owner($this->tippin)
             ->create([
-                'type' => Message::BOT_REMOVED,
+                'type' => MessengerTypes::code('BOT_REMOVED'),
                 'body' => MessageTransformer::makeBotRemoved($thread, $this->tippin, 'Test Bot')[2],
             ]);
 
@@ -925,7 +926,7 @@ class MessageTransformerTest extends FeatureTestCase
             ->for($thread)
             ->owner($this->tippin)
             ->create([
-                'type' => Message::BOT_PACKAGE_INSTALLED,
+                'type' => MessengerTypes::code('BOT_PACKAGE_INSTALLED'),
                 'body' => MessageTransformer::makeBotPackageInstalled($thread, $this->tippin, 'Test Bot')[2],
             ]);
 


### PR DESCRIPTION
This is a POC where message types are moved into service provider/facade allowing for the expansion of the type system by implementing system.

This isn't complete but the tests are passing!

What's been done:

Message type specific Resource data methods have been moved into type classes. This removes type-specific code from the resource.

Most of the hardcoded references to type codes have been removed and replaced with a Facade getter.

Definitions for system and non-system types are now defined in the MessageType repository.

Relevant tests have been updated.

There are a number of bits and pieces for the document/audio/image types which haven't been moved over and might require a bit more thought as to how they are going to be handled. Things like `->isImage()` shouldn't be necessary, but should be handled better.

There are a handful of `Message::*` for non-system messages that haven't been touched yet. I just don't want to flesh everything else out if this isn't a good direction.