### PR TITLE
Fix implicit nullable param

### DIFF
--- a/src/Messenger.php
+++ b/src/Messenger.php
@@ -64,7 +64,7 @@ final class Messenger
      * @param  bool|null  $shouldUseAbsoluteRoutes
      * @return bool
      */
-    public static function shouldUseAbsoluteRoutes(bool $shouldUseAbsoluteRoutes = null): bool
+    public static function shouldUseAbsoluteRoutes(?bool $shouldUseAbsoluteRoutes = null): bool
     {
         if (is_null($shouldUseAbsoluteRoutes)) {
             return self::$useAbsoluteRoutes;


### PR DESCRIPTION
In PHP 8.4, implicit nullable parameter types is [deprecated](https://wiki.php.net/rfc/deprecate-implicitly-nullable-types). This will raise warning everytime the function called, as it happens on my Laravel project. It's flooded my deprecation log if I don't disable the Warning log level.
<img width="auto" height="300" alt="image" src="https://github.com/user-attachments/assets/4126b121-061b-4bb1-a385-2d36c535cf3c" />

Also, to be consistent with already explicit nullable syntax on `shouldUseUuids()`.